### PR TITLE
Refactor to use the item's actual URL for the img src

### DIFF
--- a/src/Components/Card/Card.tsx
+++ b/src/Components/Card/Card.tsx
@@ -15,8 +15,7 @@ export const Card = ({ id, image }: CardProps): JSX.Element => {
   return (
     <div key={id} className='card-container'>
       <Link to={`/api/v1/users/:id/items/${id}`}>
-        {/* <img src={image} alt='Image of clothing item' className='card-image' />  */}
-        <img src="https://www.uniqlo.com/jp/ja/contents/feature/masterpiece/common_22ss/img/products/contentsArea_itemimg_16.jpg" alt='Image of clothing item' className='card-image' />
+        <img src={image} alt='Image of clothing item' className='card-image' /> 
       </Link>
       <div className='banner-container'>
         <p onClick={handleDeleteButton} className='delete-banner'><i className="fa-light fa-trash-can"></i> Delete</p>


### PR DESCRIPTION
# Description

Refactor to use the item's actual URL for the img src instead of the hard-coded url

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Styling update

# How Has This Been Tested?

- [x] Manual Testing
- [ ] Cypress Testing

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] Lint generates no new warnings
- [x] I have checked my terminal and there are no errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all cypress tests are still passing

# Comments for Reviewer(s)

- None
